### PR TITLE
Made the index page responsive

### DIFF
--- a/dev/app/(frontend)/page.tsx
+++ b/dev/app/(frontend)/page.tsx
@@ -39,11 +39,11 @@ export default async function Dashboard() {
             Schedule appointments in seconds. No account required — book as a guest or sign in to
             manage your bookings.
           </p>
-          <div className="flex gap-4 justify-center">
+          <div className="flex flex-col gap-2 items-center sm:flex-row sm:gap-4 sm:justify-center">
             <Button
               asChild
               size="lg"
-              className="bg-gradient-to-r from-violet-600 to-indigo-600 hover:from-violet-700 hover:to-indigo-700 text-white border-0 shadow-lg shadow-violet-500/25 px-8"
+              className="w-full sm:w-auto bg-gradient-to-r from-violet-600 to-indigo-600 hover:from-violet-700 hover:to-indigo-700 text-white border-0 shadow-lg shadow-violet-500/25 px-8"
             >
               <Link href="/book">Book an Appointment</Link>
             </Button>
@@ -51,7 +51,7 @@ export default async function Dashboard() {
               asChild
               variant="outline"
               size="lg"
-              className="border-gray-200 hover:bg-gray-50 px-8"
+              className="w-full sm:w-auto border-gray-200 hover:bg-gray-50 px-8"
             >
               <Link href="/login">Sign In</Link>
             </Button>

--- a/dev/components/Header/index.tsx
+++ b/dev/components/Header/index.tsx
@@ -37,7 +37,7 @@ export default async function Header() {
           </div>
           <nav className="ml-6 flex items-center space-x-2">
             <Button asChild variant="ghost" className="text-gray-600 hover:text-gray-900">
-              <Link href="/book">Book An Appointment</Link>
+              <Link href="/book">Book</Link>
             </Button>
             {isLoggedIn ? (
               <>


### PR DESCRIPTION
# What changed

Updated the CTA button layout on the index (landing) page to be mobile-first
Buttons now stack vertically on small screens and align horizontally on larger screens
CTAs take full width on mobile for better tap targets
Minor header copy tweak: shortened “Book An Appointment” → “Book” to reduce navbar clutter on smaller screens

# Why

The previous layout caused CTA buttons to feel cramped on mobile devices, also messed up the width
No behavioral or functional changes

# Screens affected

/ (index / landing page)
Header navigation

# Notes
Desktop layout remains unchanged
Tailwind-only changes, no new dependencies